### PR TITLE
Fix compilation. Still requires edits to vendor/lge/bullhead

### DIFF
--- a/aosp_bullhead.mk
+++ b/aosp_bullhead.mk
@@ -29,7 +29,7 @@ PRODUCT_DEVICE := bullhead
 PRODUCT_BRAND := Android
 PRODUCT_MODEL := AOSP on BullHead
 PRODUCT_MANUFACTURER := LGE
-PRODUCT_RESTRICT_VENDOR_FILES := true
+PRODUCT_RESTRICT_VENDOR_FILES := false
 
 #PRODUCT_COPY_FILES += device/lge/bullhead/fstab.aosp_bullhead:root/fstab.bullhead
 

--- a/device.mk
+++ b/device.mk
@@ -205,7 +205,7 @@ PRODUCT_PACKAGES += \
 
 # NFC packages
 PRODUCT_PACKAGES += \
-    com.android.nfc_extras \
+#    com.android.nfc_extras \
     nfc_nci.pn54x.default \
     NfcNci \
     Tag
@@ -252,11 +252,11 @@ PRODUCT_PACKAGES += \
 endif
 
 # sensor utilities (only for userdebug and eng builds)
-ifneq (,$(filter userdebug eng, $(TARGET_BUILD_VARIANT)))
-PRODUCT_PACKAGES += \
-    nanotool \
-    sensortest
-endif
+#ifneq (,$(filter userdebug eng, $(TARGET_BUILD_VARIANT)))
+#PRODUCT_PACKAGES += \
+#    nanotool \
+#    sensortest
+#endif
 
 PRODUCT_PACKAGES += \
     keystore.msm8992 \

--- a/proprietary-blobs-vendorimg.txt
+++ b/proprietary-blobs-vendorimg.txt
@@ -17,8 +17,6 @@
 #
 # <src relative to root of extracted filesystem>:<dst relative to system>
 
--app/datastatusnotification/datastatusnotification.apk
--app/ims/ims.apk
 lib64/libimscamera_jni.so
 lib64/libimscamera_jni.so:app/ims/lib/arm64/libimscamera_jni.so
 lib64/libimsmedia_jni.so

--- a/proprietary-blobs.txt
+++ b/proprietary-blobs.txt
@@ -18,23 +18,6 @@
 #
 # <src relative to root of extracted filesystem>:<dst relative to system>
 
--app/HiddenMenu/HiddenMenu.apk
--app/RCSBootstraputil/RCSBootstraputil.apk
--app/RcsImsBootstraputil/RcsImsBootstraputil.apk
--app/TimeService/TimeService.apk
--app/Tycho/Tycho.apk:app/Tycho/Tycho.apk:PRESIGNED
--priv-app/atfwd/atfwd.apk
--priv-app/CNEService/CNEService.apk
--priv-app/ConnMO/ConnMO.apk
--priv-app/DCMO/DCMO.apk
--priv-app/DiagMon/DiagMon.apk
--priv-app/DMConfigUpdate/DMConfigUpdate.apk
--priv-app/DMService/DMService.apk
--priv-app/GCS/GCS.apk:priv-app/GCS/GCS.apk:PRESIGNED
--priv-app/HotwordEnrollment/HotwordEnrollment.apk:priv-app/HotwordEnrollment/HotwordEnrollment.apk:PRESIGNED
--priv-app/LifeTimerService/LifeTimerService.apk
--priv-app/SprintDM/SprintDM.apk
--priv-app/qcrilmsgtunnel/qcrilmsgtunnel.apk
 bin/ATFWD-daemon
 bin/btnvtool
 bin/cnd


### PR DESCRIPTION
This is the only change that can be made without forking the vendor repository, but it makes compiling a little easier out of the box.

Still required for successful compilation is commenting out the entirety of vendor/lge/bullhead/Android.mk

Change-Id: Ic9a06d58e02fdccdec1acdb034dfdc21e6426840